### PR TITLE
Handle invalid segment IDs gracefuly

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,9 @@ func main() {
 					segment, err = shm.Create(size)
 				} else {
 					if segmentId, err := strconv.ParseUint(c.Args().First(), 10, 64); err == nil {
-						segment, err = shm.Open(int(segmentId))
+						if segment, err = shm.Open(int(segmentId)); err != nil {
+							log.Fatalf("Failed to open segment %d: %v", segmentId, err)
+						}
 					} else {
 						log.Fatalf("Failed to parse segment ID: %v", err)
 						return


### PR DESCRIPTION
Fixes:

```
juergen@lemmy:~ → shmtool open  11
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5b57d4]

goroutine 1 [running]:
main.main.func2(0xc0002ca280)
	/home/juergen/go/src/github.com/ghetzel/shmtool/main.go:83 +0x254
github.com/ghetzel/cli.Command.Run(0x6287f3, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x63501f, 0x54, 0x0, ...)
	/home/juergen/go/src/github.com/ghetzel/cli/command.go:179 +0x873
github.com/ghetzel/cli.(*App).Run(0xc0000a62c0, 0xc000012180, 0x3, 0x3, 0x0, 0x0)
	/home/juergen/go/src/github.com/ghetzel/cli/app.go:196 +0x91d
main.main()
	/home/juergen/go/src/github.com/ghetzel/shmtool/main.go:157 +0x54b
```

:arrow_down: 

```
juergen@lemmy:~ → shmtool open  11
[14:28:56 0001] CRIT Failed to open segment 11: invalid argument

```